### PR TITLE
fix(lib): Disable Tokio and fix compilation for WASM target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["todo", "rememberthemilk"]
 categories = ["api-bindings", "command-line-utilities"]
 
 [dependencies]
-tokio = { version = "1.0", features = ["full"] }
 reqwest = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -30,6 +29,9 @@ tui-tree-widget = { version = "0.19", optional = true }
 crossterm = { version = "0.27", optional = true, features = ["event-stream"] }
 tokio-stream = "0.1.12"
 unicode-width = "0.1.10"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.0", features = ["full"] }
 
 [[bin]]
 name = "rtm"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,7 @@ struct AuthResponse {
     stat: Stat,
     auth: Auth,
 }
-
+#[allow(dead_code)]
 trait RTMToResult {
     type Type;
     fn into_result(self) -> Result<Self::Type, RTMError>;


### PR DESCRIPTION
Hello,
Thank you for your crate! 
This pull request makes some tweaks to the build process of the library to get it working in a WASM (WebAssembly) environment. Specifically, these changes help when using the crate in Cloudflare Workers, which compile against WASM. I use the following command to build the library for the WASM target:

`cargo build --lib --release --no-default-features --target wasm32-unknown-unknown`

Adding the crate into another project's Cargo.toml will requires some adjustments:

```
rememberthemilk = { version="0.4.0", default-features = false }
```

Please let me know if you see any issue with this approach.