### PR TITLE
feat: Add Priority field and URL setter to the task structure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,6 +372,8 @@ pub struct Task {
     #[serde(deserialize_with = "empty_string_as_none")]
     /// The date/time when this task was completed
     pub completed: Option<DateTime<Utc>>,
+    /// The task's priority
+    pub priority: String,
 }
 
 /// Describes how much time is left to complete this task, or perhaps

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,6 +480,12 @@ struct AddTagResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+struct SetURLResponse {
+    stat: Stat,
+    list: RTMLists,
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 struct AddTaskResponse {
     stat: Stat,
     transaction: Option<Transaction>,
@@ -899,6 +905,47 @@ impl API {
                 .rsp
                 .timeline;
             Ok(RTMTimeline(tl))
+        } else {
+            bail!("Unable to fetch tasks")
+        }
+    }
+
+    /// Add one or more tags to a task.
+    ///
+    /// * `timeline`: a timeline as retrieved using [API::get_timeline]
+    /// * `list`, `taskseries` and `task` identify the task to tag.
+    /// * `url` is a String with url to add to this task.
+    ///
+    /// Requires a valid user authentication token.
+    pub async fn set_url(
+        &self,
+        timeline: &RTMTimeline,
+        list: &RTMLists,
+        taskseries: &TaskSeries,
+        task: &Task,
+        url: &str,
+    ) -> Result<(), Error> {
+        if let Some(ref tok) = self.token {
+            let params = &[
+                ("method", "rtm.tasks.setURL"),
+                ("format", "json"),
+                ("api_key", &self.api_key),
+                ("auth_token", &tok),
+                ("timeline", &timeline.0),
+                ("list_id", &list.id),
+                ("taskseries_id", &taskseries.id),
+                ("task_id", &task.id),
+                ("url", &url),
+            ];
+            let response = self
+                .make_authenticated_request(&self.get_rest_url(), params)
+                .await?;
+            let rsp = from_str::<RTMResponse<SetURLResponse>>(&response)?.rsp;
+            if let Stat::Ok = rsp.stat {
+                Ok(())
+            } else {
+                bail!("Error adding task")
+            }
         } else {
             bail!("Unable to fetch tasks")
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -70,6 +70,7 @@ fn test_deser_taskseries() {
             ),
             deleted: None,
             has_due_time: false,
+            priority: "N".into(),
         }],
         tags: vec!["computer".into()],
         notes: Default::default(),
@@ -115,6 +116,7 @@ fn test_deser_task_nodue() {
         ),
         deleted: None,
         has_due_time: false,
+        priority: "N".into(),
     };
     println!("{}", to_string(&expected).unwrap());
     let task = from_str::<Task>(json).unwrap();
@@ -196,6 +198,7 @@ fn test_deser_tasklist_response() {
                         ),
                         deleted: None,
                         has_due_time: false,
+                        priority: "N".into(),
                     }],
                     tags: vec!["computer".into()],
                     repeat: None,
@@ -312,6 +315,7 @@ fn test_deser_tasklist_response_notes() {
                         ),
                         deleted: None,
                         has_due_time: false,
+                        priority: "N".into(),
                     }],
                     tags: vec!["computer".into()],
                     repeat: None,


### PR DESCRIPTION
Hello,
While working with the library, I noticed that the priority field wasn't included in the Task structure, which made it inaccessible. To address this, I've implemented a basic version of the priority field, making it part of the task structure. Additionally, I added a method to set the URL for a task, which I believe will be a useful enhancement.

Note: I'm not entirely confident in the implementation of these features, so I would greatly appreciate any feedback or suggestions for improvement.
Thanks!